### PR TITLE
Fix the contract address for the TrueUSD (TUSD) coin

### DIFF
--- a/aeb.tokenlist.json
+++ b/aeb.tokenlist.json
@@ -2567,7 +2567,7 @@
         },
         {
             "chainId": 43114,
-            "address": "0xc458770B5fA66f4DF1498c3D824261D5f5EC3582",
+            "address": "0x1C20E891Bab6b1727d14Da358FAe2984Ed9B59EB",
             "decimals": 18,
             "name": "TrueUSD",
             "symbol": "TUSD",


### PR DESCRIPTION
Point the contract address for TUSD to the correct place.  https://cchain.explorer.avax.network/address/0x1C20E891Bab6b1727d14Da358FAe2984Ed9B59EB/transactions

I'm not sure what the prior address was, but it's not the thing TrueUSD is using to mint coins on avalanche and it doesn't appear to have any meaningful transactions running against it.  https://cchain.explorer.avax.network/address/0xc458770B5fA66f4DF1498c3D824261D5f5EC3582/transactions